### PR TITLE
Set default combo from 0 to 1

### DIFF
--- a/SUBLEERUNKER/scenes/play/session/ingame/ingame.gd
+++ b/SUBLEERUNKER/scenes/play/session/ingame/ingame.gd
@@ -19,7 +19,8 @@ var combo_exists = false
 const COMBO_COOLTIME_MIN := 0.75
 const COMBO_COOLTIME_MAX := 1.5
 var combo_cooltime := 0.0
-var n_combo := 0
+const N_COMBO_BASE := 1
+var n_combo := N_COMBO_BASE
 
 var game_objects: Node
 var player: Node
@@ -39,6 +40,7 @@ func _ready():
 	_connect_signals()
 	# Init
 	Signals.emit_signal("scored", score)
+	Signals.emit_signal("game_combo_updated", n_combo)
 
 
 func _process(delta):
@@ -182,7 +184,7 @@ func _on_game_combo_succeeded(combo):
 
 
 func _on_game_combo_failed(combo):
-	n_combo = 0
+	n_combo = N_COMBO_BASE
 	Signals.emit_signal("game_combo_updated", n_combo)
 
 	combo_cooltime = _next_combo_cooltime()


### PR DESCRIPTION
Improve #11 

There was feedback saying it's frustrating when the player missed the combo in the end game because once they missed, they will get 0 score until they hit the next combo, which is barely possible.

By setting the default combo to 1, I expect that people get a little more motivated when they missed the combo in the end game